### PR TITLE
Fix Trailing whitesspace to please clang-format-13+

### DIFF
--- a/src/Configuration.hpp
+++ b/src/Configuration.hpp
@@ -4,7 +4,7 @@
 /*
 A yaml configuration reader.
 
-Data is read from a yaml file in the constructor and accessible then. 
+Data is read from a yaml file in the constructor and accessible then.
 */
 struct Configuration {
 


### PR DESCRIPTION
Might also be caught by clang-format-11 and -12 which I did not test.